### PR TITLE
Update location of test manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /downloads/
 /tools/
 /wptrunner/
-/meta/

--- a/roles/wptrunner/tasks/main.yml
+++ b/roles/wptrunner/tasks/main.yml
@@ -19,6 +19,6 @@
   shell: |
     mkdir meta && \
     cd web-platform-tests && \
-    python manifest --path ../meta/MANIFEST.json
+    python manifest
   args:
-    creates: meta/MANIFEST.json
+    creates: web-platform-tests/MANIFEST.json

--- a/runtests
+++ b/runtests
@@ -35,5 +35,6 @@ fi
 wptrunner \
   --certutil-binary openssl \
   --tests ./web-platform-tests/ \
+  --manifest ./web-platform-tests/MANIFEST.json \
   $product_args \
   ${@:2}


### PR DESCRIPTION
Because the Web Platform Tests' project's `manifest` script generates a
file in the root of that project by default, and because that script is
likely to be used directly by development, this project should configure
the development environment according to default behavior (limiting the
amount of environment-specific details in the development workflow).

(Note that the `web-platform-tests` project already contains an entry for this file in its `.gitignore` file.)